### PR TITLE
Update _sandbox.py Fix ZipSlip bypass

### DIFF
--- a/src/safezip/_sandbox.py
+++ b/src/safezip/_sandbox.py
@@ -82,6 +82,10 @@ def resolve_member_path(
             part = part[2:]
             if not part:
                 continue
+            if part == "..":
+                raise UnsafeZipError(
+                    f"Path traversal detected in filename: {member_filename!r}"
+                )
         clean_parts.append(part)
 
     if not clean_parts:
@@ -94,7 +98,7 @@ def resolve_member_path(
 
     # 5. Confirm the resolved path is inside base
     try:
-        resolved.relative_to(base)
+        resolved.resolve().relative_to(base.resolve())
     except ValueError as err:
         raise UnsafeZipError(
             f"Resolved path escapes base directory: {resolved!r} is not under {base!r}"


### PR DESCRIPTION
resolve_member_path in _sandbox.py can be bypassed with a filename like C:../C:../etc/target — the drive-letter strip turns C:.. into .. after the traversal check, and relative_to() without .resolve() doesn't catch it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ZIP member path validation with stricter checks for path traversal attempts and improved handling of Windows-style paths to ensure paths remain within the intended directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->