### PR TITLE
Update _sandbox.py Fix ZipSlip bypass

### DIFF
--- a/src/safezip/_sandbox.py
+++ b/src/safezip/_sandbox.py
@@ -98,8 +98,10 @@ def resolve_member_path(
 
     # 5. Confirm the resolved path is inside base
     try:
-        resolved.resolve().relative_to(base.resolve())
-    except ValueError as err:
+        resolved_real = resolved.resolve()
+        base_real = base.resolve()
+        resolved_real.relative_to(base_real)
+    except (ValueError, RuntimeError, OSError) as err:
         raise UnsafeZipError(
             f"Resolved path escapes base directory: {resolved!r} is not under {base!r}"
         ) from err
@@ -165,7 +167,7 @@ def _verify_symlink_chain(link_path: Path, base: Path) -> None:
 
         try:
             current.resolve().relative_to(base.resolve())
-        except ValueError as err:
+        except (ValueError, RuntimeError, OSError) as err:
             raise UnsafeZipError(
                 f"Symlink chain for {link_path} exits the base directory "
                 f"at {current} → {current.resolve()}"

--- a/src/safezip/_sandbox.py
+++ b/src/safezip/_sandbox.py
@@ -82,6 +82,10 @@ def resolve_member_path(
             part = part[2:]
             if not part:
                 continue
+            if part == "..":
+                raise UnsafeZipError(
+                    f"Path traversal detected in filename: {member_filename!r}"
+                )
         clean_parts.append(part)
 
     if not clean_parts:
@@ -94,7 +98,7 @@ def resolve_member_path(
 
     # 5. Confirm the resolved path is inside base
     try:
-        resolved.relative_to(base)
+        resolved.resolve().relative_to(base.resolve())
     except ValueError as err:
         raise UnsafeZipError(
             f"Resolved path escapes base directory: {resolved!r} is not under {base!r}"


### PR DESCRIPTION
resolve_member_path in _sandbox.py can be bypassed with a filename like C:../C:../etc/target — the drive-letter strip turns C:.. into .. after the traversal check, and relative_to() without .resolve() doesn't catch it.

This time i used the dev branch as per ur request, lmk if i need to do it a diff way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced path traversal attack prevention with stricter validation checks.
  * Improved base-directory containment verification to prevent unauthorized path access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->